### PR TITLE
Improved handling of non-existent TDB2 record fields when exporting/importing tables

### DIFF
--- a/src/server/editors/db-editor-service.js
+++ b/src/server/editors/db-editor-service.js
@@ -162,7 +162,12 @@ dbService.exportTable = async (tableName, options) => {
     });
 
     const data = table.records.map((record) => {
-        return Object.keys(record.fields).map((fieldKey) => { 
+        return headers.map((fieldKey) => { 
+            if(!record.fields[fieldKey])
+            {
+                return '';
+            }
+            
             const field = record.fields[fieldKey];
             return field.value;
         });
@@ -199,6 +204,10 @@ dbService.importTable = async (tableName, options) => {
         let record = table.records[index];
 
         Object.keys(row).forEach((fieldKey) => {
+            if(!record.fields[fieldKey]) {
+                return;
+            }
+           
             record.fields[fieldKey].value = row[fieldKey];
         });
     });


### PR DESCRIPTION
Previously, if a TDB2 file was opened in the DB editor and had a table where some records have fields that other records don't, while the editor GUI would display a cell for every record (showing an empty cell for records that don't have that field), exporting the table to CSV/XLSX would cause the column alignment to be incorrect as these empty cells were not being handled properly.

Updated the db-editor-service to iterate through the table's fieldDefinitions when exporting instead of the keys in the record's fields object. This makes sure that it checks every possible field in a table, not just the ones that the record currently being processed has. If a record doesn't have a field, a blank value is placed in the corresponding cell in the exported sheet.

Also updated the import feature to skip fields that don't exist in the record being processed, to ensure these exported tables can be imported back in without issue.